### PR TITLE
feat: add outputs for default NACL, security group and route table created with VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_nat_instance"></a> [ec2\_nat\_instance](#module\_ec2\_nat\_instance) | git::https://github.com/TechHoldingLLC/terraform-aws-ec2.git | v1.0.0 |
+| <a name="module_ec2_nat_instance"></a> [ec2\_nat\_instance](#module\_ec2\_nat\_instance) | git::https://github.com/TechHoldingLLC/terraform-aws-ec2.git | v1.0.1 |
 | <a name="module_nat_instance_sg"></a> [nat\_instance\_sg](#module\_nat\_instance\_sg) | git::https://github.com/TechHoldingLLC/terraform-aws-security-group.git | v0.0.1 |
 
 ## Resources
@@ -67,6 +67,9 @@
 |------|-------------|
 | <a name="output_availability_zones"></a> [availability\_zones](#output\_availability\_zones) | n/a |
 | <a name="output_cidr_block"></a> [cidr\_block](#output\_cidr\_block) | n/a |
+| <a name="output_default_nacl_id"></a> [default\_nacl\_id](#output\_default\_nacl\_id) | n/a |
+| <a name="output_default_route_table_id"></a> [default\_route\_table\_id](#output\_default\_route\_table\_id) | n/a |
+| <a name="output_defaut_security_group_id"></a> [defaut\_security\_group\_id](#output\_defaut\_security\_group\_id) | n/a |
 | <a name="output_id"></a> [id](#output\_id) | n/a |
 | <a name="output_name"></a> [name](#output\_name) | n/a |
 | <a name="output_nat_gateway_id"></a> [nat\_gateway\_id](#output\_nat\_gateway\_id) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,18 @@ output "availability_zones" {
   value = slice(data.aws_availability_zones.available.names, 0, var.number_of_aws_az_use)
 }
 
+output "default_nacl_id" {
+  value = aws_vpc.vpc.default_network_acl_id
+}
+
+output "default_route_table_id" {
+  value = aws_vpc.vpc.default_route_table_id
+}
+
+output "default_security_group_id" {
+  value = aws_vpc.vpc.default_security_group_id
+}
+
 output "cidr_block" {
   value = aws_vpc.vpc.cidr_block
 }


### PR DESCRIPTION
Add outputs to extract IDs of default:
- NACL
- Security Group
- Route Table